### PR TITLE
Set Axios timeout to 10 secs.

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,7 +3,11 @@
 const axios = require('axios')
 const auth = require("./auth");
 
-const baseURL = 'https://financialmodelingprep.com/api/';
+/* FMP instance with Axios defaults. */ 
+const fmp = axios.create({
+    baseURL: 'https://financialmodelingprep.com/api',
+    timeout: 10000 // 10 secs
+});
 
 /**
  * Creates the endpoint using the default base URL and adding the respective
@@ -26,7 +30,7 @@ const url = (params) => {
     let pathParameters = params['path'];
     let urlPath = params['urlPath'];
     let apiVersion = params['apiVersion'] || 'v3';
-    let url = baseURL + apiVersion + '/';
+    let url = apiVersion + '/';
     let queryString = '';
     let apikey = auth.key;
     url += urlPath;
@@ -54,7 +58,6 @@ const url = (params) => {
     }
 
     url += `apikey=${apikey}`;
-
     return url;
 }
 
@@ -84,7 +87,12 @@ function generateJson(pathParam, queryParam = undefined, apiVersion = undefined)
 }
 
 module.exports = {
-    makeRequest: (path, params = {}) => axios.get(url(Object.assign({}, params, { urlPath: path })))
-                                        .then(response => response.data).catch(err => err.response),
+    makeRequest: (path, params = {}) => fmp.get(url(Object.assign({}, params, { urlPath: path })))
+        .then(response => response.data).catch(err => {
+            console.error('Axios:', err.message);
+            if (err.response) {
+                return err.response;
+            } else return new Response({}, { status: 504, statusText: err.message});
+        }),
     generateJson: generateJson
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fmpclouds",
+  "name": "fmpcloud",
   "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fmpclouds",
+      "name": "fmpcloud",
       "version": "1.1.4",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fmpclouds",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fmpclouds",
-      "version": "1.1.2",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.4"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "financialmodelingprep",
+  "name": "fmpcloud",
   "version": "1.1.4",
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fmpclouds",
-  "version": "1.1.3",
+  "name": "financialmodelingprep",
+  "version": "1.1.4",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/viswatj/fmpcloud/issues",
-    "email": "patelneel55@gmail.com"
+    "email": "viswa.isttm@gmail.com"
   },
   "homepage": "https://github.com/viswatj/fmpcloud/",
   "dependencies": {


### PR DESCRIPTION
Axios has no default timeout setting. This causes issues when deployed in environments that do have a response timeout. A standard response timeout of 10s should be sufficient for the FMP API.